### PR TITLE
Timing issues (do not pull :p)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+0.05_03
+    - Some platforms don't use time based UUID generation even when asked to
+
 0.05_02
     - Attempt to reseed only on OSX for now
 

--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.05_02
+    - Attempt to reseed only on OSX for now
+
+0.05_01
+    - Attempt to reseed the random number generator at least on OSX
+
 0.04
     - Avoid using the non portable POPpx
 

--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.05
+    - non dev release
+
+0.05_04
+    - fix broken test plan
+
 0.05_03
     - Some platforms don't use time based UUID generation even when asked to
 

--- a/LibUUID.xs
+++ b/LibUUID.xs
@@ -9,13 +9,9 @@
 
 #include <uuid/uuid.h>
 
-#ifndef NO_SRANDDEV_ON_FORK
-#define PID_CHECK pid_check()
 #ifdef PERL_DARWIN
+#define PID_CHECK pid_check()
 #include <stdlib.h>
-/* FIXME for older versions of OSX this might need to be sranddev() or srandomdev() */
-#define sranddev() arc4random_stir();
-#endif
 #else
 #define PID_CHECK
 #endif
@@ -63,7 +59,7 @@ static pid_t last_pid = 0;
 inline STATIC void pid_check () {
     if ( getpid() != last_pid ) {
         last_pid = getpid();
-        sranddev();
+        arc4random_stir();
     }
 }
 

--- a/lib/Data/UUID/LibUUID.pm
+++ b/lib/Data/UUID/LibUUID.pm
@@ -6,7 +6,7 @@ use strict;
 
 use vars qw($VERSION @ISA);
 
-$VERSION = '0.05_02';
+$VERSION = '0.05_03';
 
 use Time::HiRes ();
 

--- a/lib/Data/UUID/LibUUID.pm
+++ b/lib/Data/UUID/LibUUID.pm
@@ -6,7 +6,7 @@ use strict;
 
 use vars qw($VERSION @ISA);
 
-$VERSION = '0.05_03';
+$VERSION = '0.05_04';
 
 use Time::HiRes ();
 

--- a/lib/Data/UUID/LibUUID.pm
+++ b/lib/Data/UUID/LibUUID.pm
@@ -6,7 +6,7 @@ use strict;
 
 use vars qw($VERSION @ISA);
 
-$VERSION = '0.05_04';
+$VERSION = '0.05';
 
 use Time::HiRes ();
 

--- a/lib/Data/UUID/LibUUID.pm
+++ b/lib/Data/UUID/LibUUID.pm
@@ -6,7 +6,7 @@ use strict;
 
 use vars qw($VERSION @ISA);
 
-$VERSION = '0.05_01';
+$VERSION = '0.05_02';
 
 use Time::HiRes ();
 

--- a/lib/Data/UUID/LibUUID.pm
+++ b/lib/Data/UUID/LibUUID.pm
@@ -88,7 +88,8 @@ __END__
 
 =head1 NAME
 
-Data::UUID::LibUUID - F<uuid.h> based UUID generation (versions 1, 2 and 4)
+Data::UUID::LibUUID - F<uuid.h> based UUID generation (versions 2 and 4
+depending on platform)
 
 =head1 SYNOPSIS
 
@@ -111,16 +112,21 @@ debian, and also works with the system F<uuid.h> on darwin.
 
 Returns a new UUID in string (dash separated hex) or binary (16 octets) format.
 
-C<$version> can be 1, 2, or 4 and defaults to 2.
+C<$version> can be either 2, or 4 and defaults to whatever the underlying
+implementation prefers.
 
 Version 1 is timestamp/MAC based UUIDs, like L<Data::UUID> provides. They
 reveal time and host information, so they may be considered a security risk.
 
 Version 2 is described here
-L<http://www.opengroup.org/onlinepubs/9696989899/chap5.htm#tagcjh_08_02_01_01>
+L<http://www.opengroup.org/onlinepubs/9696989899/chap5.htm#tagcjh_08_02_01_01>.
+It is similar to version 1 but considered more secure.
 
 Version 4 is based just on random data. This is not guaranteed to be high
-quality random data.
+quality random data, but usually is supposed to be.
+
+On MacOS X C<getpid> is called before UUID generation, to ensure UUIDs are
+unique accross forks. Behavior on other platforms may vary.
 
 =item uuid_to_binary $str_or_bin
 

--- a/lib/Data/UUID/LibUUID.pm
+++ b/lib/Data/UUID/LibUUID.pm
@@ -6,7 +6,7 @@ use strict;
 
 use vars qw($VERSION @ISA);
 
-$VERSION = '0.04';
+$VERSION = '0.05_01';
 
 use Time::HiRes ();
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -12,9 +12,10 @@ foreach my $version (1, 2, 4) {
     is( length(new_uuid_string($version)), 36, "new_uuid_string($version)" );
 }
 
-my ( $t1, $t2 ) = map { unpack("N",new_uuid_binary(1)) } 1 .. 2;
+# doesn't pass on all platforms
+#my ( $t1, $t2 ) = map { unpack("N",new_uuid_binary(1)) } 1 .. 2;
 
-cmp_ok( $t1 - $t2, '<=', 1, "time based UUIDs have close prefix" );
+#cmp_ok( $t1 - $t2, '<=', 1, "time based UUIDs have close prefix" );
 
 my $bin = new_uuid_binary();
 is( length($bin), 16, "binary UUID" );

--- a/t/basic.t
+++ b/t/basic.t
@@ -2,7 +2,7 @@
 
 use strict;
 
-use Test::More tests => 48;
+use Test::More tests => 47;
 
 use ok 'Data::UUID::LibUUID' => ":all";
 

--- a/t/fork.t
+++ b/t/fork.t
@@ -1,0 +1,44 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+BEGIN {
+    use File::Spec;
+	if ( File::Spec->isa("File::Spec::Unix") ) {
+		plan 'no_plan';
+	} else {
+		plan skip_all => "not running on something UNIXish";
+	}
+}
+
+
+use ok 'Data::UUID::LibUUID' => ":all";
+
+for ( 1 .. 2 ) {
+    my @uuids;
+
+    foreach my $child ( 1 .. 3 ) {
+        my $pid = open my $handle, "-|";
+        die $! unless defined $pid;
+
+        if ( $pid ) {
+            push @uuids, <$handle>;
+            close $handle;
+        } else {
+            print new_uuid_string();
+            exit;
+        }
+    }
+
+    push @uuids, new_uuid_string();
+
+    while ( @uuids ) {
+        my $str = shift @uuids;
+        isnt( $str, $_ ) for @uuids;
+    }
+}
+
+

--- a/t/fork.t
+++ b/t/fork.t
@@ -31,6 +31,13 @@ for ( 1 .. 2 ) {
             print new_uuid_string();
             exit;
         }
+        sleep 1; # This makes the test pass, but it scares the bajebus out of me.
+                 # Does that mean there could be collisions if
+                 # new_uuid_string() is called very close in time?
+                 #
+                 # Also the fact that it fails differently gives me the
+                 # impressions that it is a timing issue or what one should
+                 # call it.
     }
 
     push @uuids, new_uuid_string();


### PR DESCRIPTION
Not really a pull request, just a puzzeling question.

I explained on IRC as well, but this might be a more "long living" explanation.

The issue is that on our buildserver `t/fork.t` fails in random ways, with duplicate UUID's generated.

As I annotated in `t/fork.t`, `sleep 1;` fixes it, but it can't possibly be the right fix. This to me sounds like some sort of underlying problem?
