### PR TITLE
Timing issues (do not pull :p)

### DIFF
--- a/t/fork.t
+++ b/t/fork.t
@@ -31,6 +31,13 @@ for ( 1 .. 2 ) {
             print new_uuid_string();
             exit;
         }
+        sleep 1; # This makes the test pass, but it scares the bajebus out of me.
+                 # Does that mean there could be collisions if
+                 # new_uuid_string() is called very close in time?
+                 #
+                 # Also the fact that it fails differently gives me the
+                 # impressions that it is a timing issue or what one should
+                 # call it.
     }
 
     push @uuids, new_uuid_string();


### PR DESCRIPTION
Not really a pull request, just a puzzeling question.

I explained on IRC as well, but this might be a more "long living" explanation.

The issue is that on our buildserver `t/fork.t` fails in random ways, with duplicate UUID's generated.

As I annotated in `t/fork.t`, `sleep 1`; fixes it, but it can't possibly be the right fix. This to me sounds like some sort of underlying problem?

(and sorry for the noise with two requests, messed up branch points on first one)
